### PR TITLE
Create datadog-synthetics.yml

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -1,0 +1,38 @@
+# This workflow will trigger Datadog Synthetic tests within your Datadog organisation
+# For more information on running Synthetic tests within your GitHub workflows see: https://docs.datadoghq.com/synthetics/cicd_integrations/github_actions/
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# To get started:
+
+# 1. Add your Datadog API (DD_API_KEY) and Application Key (DD_APP_KEY) as secrets to your GitHub repository. For more information, see: https://docs.datadoghq.com/account_management/api-app-keys/.
+# 2. Start using the action within your workflow
+
+name: Run Datadog Synthetic tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # Run Synthetic tests within your GitHub workflow.
+    # For additional configuration options visit the action within the marketplace: https://github.com/marketplace/actions/datadog-synthetics-ci
+    - name: Run Datadog Synthetic tests
+      uses: DataDog/synthetics-ci-github-action@87b505388a22005bb8013481e3f73a367b9a53eb # v1.4.0
+      with:
+        api_key: ${{secrets.DD_API_KEY}}
+        app_key: ${{secrets.DD_APP_KEY}}
+        test_search_query: 'tag:e2e-tests' #Modify this tag to suit your tagging strategy
+
+

--- a/dimension
+++ b/dimension
@@ -1,0 +1,33 @@
+s => {
+#  "dimensionHeaders": [
+#    {
+#      "name": "sessionDefaultChannelGroup"
+#    }
+#  ],
+#  "metricHeaders": [
+#    {
+#      "name": "sessions",
+#      "type": "TYPE_INTEGER"
+#    }
+#  ],
+#  "rows": [
+#    {
+#      "dimensionValues": [
+#        {
+#          "value": "Organic Search"
+#        }
+#      ],
+#      "metricValues": [
+#        {
+#          "value": "200"
+#        }
+#      ]
+#    }
+#  ],
+#  "rowCount": 1,
+#  "metadata": {
+#    "currencyCode": "JPY",
+#    "timeZone": "Asia/Tokyo"
+#  },
+#  "kind": "analyticsData#runReport"
+#}

--- a/ファイルを取得
+++ b/ファイルを取得
@@ -1,0 +1,38 @@
+# ファイルを取得
++get_file_1:
+  action>: GetFile
+  display_name>: 'ファイルを取得'
+  provider: local
+  filename: rc_36b0011677688bf489d7
+  private: false
+  meta:
+    display:
+      filename:
+        label: 'sample-card.png'
+        icon: text
+        type: chip
+    action:
+      disabled: false
+# Document Forceでドキュメントを解析
++d_f_analyze_document_1:
+  action>: DFAnalyzeDocument
+  display_name>: 'Document Forceでドキュメントを解析'
+  provider_id: documentforce_03f3151d6f9accddcffa
+  endpoint: 'https://app.aipuncher.com/api/v2/analyse/****************'
+  file: +get_file_1
+  tags:
+    AUTORO DevOps:
+      - '開発テストタグ'
+  wait_for_result: false
+  private: false
+  meta:
+    display:
+      provider_id:
+        type: chip
+        label: 'Documentforce (AUTORO連携用)'
+        icon: documentforce
+    action:
+      disabled: false
+# {
+#   "document_id": 1027
+# }


### PR DESCRIPTION
Pick folder 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 在 `main` 分支的提交与拉取请求中自动触发 Datadog Synthetics 测试，执行 `e2e-tests` 标签用例，并通过密钥完成鉴权。
* **Chores**
  * 新增工作流步骤：先获取示例文件，再调用 Document Force 解析接口处理文件内容；同时配置了结果等待策略与展示元信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->